### PR TITLE
fix: type error

### DIFF
--- a/doc/shorturl-en.md
+++ b/doc/shorturl-en.md
@@ -430,8 +430,8 @@ Till now, we’ve done the modification of API Gateway. All the manually added c
 
   ```go
   type ServiceContext struct {
-  	c     config.Config
-    Model *model.ShorturlModel   // manual code
+    c     config.Config
+    Model model.ShorturlModel   // manual code
   }
   
   func NewServiceContext(c config.Config) *ServiceContext {

--- a/doc/shorturl.md
+++ b/doc/shorturl.md
@@ -453,7 +453,7 @@
   ```go
   type ServiceContext struct {
     c     config.Config
-    Model *model.ShorturlModel   // 手动代码
+    Model model.ShorturlModel   // 手动代码
   }
   
   func NewServiceContext(c config.Config) *ServiceContext {


### PR DESCRIPTION
> cannot use model.NewShorturlModel(sqlx.NewMysql(c.DataSource)) (type model.ShorturlModel) as type *model.ShorturlModel in field value:*model.ShorturlModel is pointer to interface, not interface